### PR TITLE
whitelist 10.* ips for kubernetes

### DIFF
--- a/copy_cache/clientportal.gw/root/conf.yaml
+++ b/copy_cache/clientportal.gw/root/conf.yaml
@@ -22,6 +22,7 @@ webApps:
     index: "index.html"
 ips:
   allow:
+    - 10.*
     - 192.*
     - 131.216.*
     - 127.0.0.1


### PR DESCRIPTION
Whitelist by default all `10.*.*.*` ports  that Kubernetes uses internally to allow other services/pods in kubernetes to talk to IBeam